### PR TITLE
Faded indicators rework

### DIFF
--- a/src/BikeSack/BikeSack.java
+++ b/src/BikeSack/BikeSack.java
@@ -8,6 +8,7 @@ public class BikeSack {
 
 	
 	public static final int MAX_FADE_CURRENT = 15;
+	public static final int START_FADE_CURRENT = 1;
 
 	// Set up constants for the keyboard inputs
 	public static final String LEFT_INDICATOR_KEY = "L";
@@ -69,24 +70,24 @@ public class BikeSack {
 			break;
 		case LEFT_INDICATOR_KEY:
 			// Left Indicator
-			sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).toggle();
+			sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).toggle(START_FADE_CURRENT);
 			System.out.println("Sensor [Type= LEFT_INDICATOR, State= "
 					+ sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).getCurrent() + "]");
 			if (sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).getCurrent() != sensors
 					.get(CONNECTED_SENSORS.RIGHT_INDICATOR).getMin()) {
-				sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).toggle();
+				sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).toggle(START_FADE_CURRENT);
 				System.out.println("Sensor [Type= RIGHT_INDICATOR, State= "
 						+ sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).getCurrent() + "]");
 			}
 			break;
 		case RIGHT_INDICATOR_KEY:
 			// Right Indicator
-			sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).toggle();
+			sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).toggle(START_FADE_CURRENT);
 			System.out.println("Sensor [Type= RIGHT_INDICATOR, State= "
 					+ sensors.get(CONNECTED_SENSORS.RIGHT_INDICATOR).getCurrent() + "]");
 			if (sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).getCurrent() != sensors
 					.get(CONNECTED_SENSORS.LEFT_INDICATOR).getMin()) {
-				sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).toggle();
+				sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).toggle(START_FADE_CURRENT);
 				System.out.println("Sensor [Type= LEFT_INDICATOR, State= "
 						+ sensors.get(CONNECTED_SENSORS.LEFT_INDICATOR).getCurrent() + "]");
 			}

--- a/src/BikeSack/BikeSack.java
+++ b/src/BikeSack/BikeSack.java
@@ -6,7 +6,7 @@ import java.util.Scanner;
 
 public class BikeSack {
 
-	// Should this go in output class?
+	
 	public static final int MAX_FADE_CURRENT = 10;
 
 	// Set up constants for the keyboard inputs
@@ -133,9 +133,9 @@ public class BikeSack {
 		sensors.put(CONNECTED_SENSORS.BRAKE, new Sensor(0, 1));
 		sensors.put(CONNECTED_SENSORS.FUEL, new Sensor(0, 50, 25, 0));
 		sensors.put(CONNECTED_SENSORS.HIGH_BEAM, new Sensor(0, 1));
-		sensors.put(CONNECTED_SENSORS.LEFT_INDICATOR, new Sensor(0, 1));
+		sensors.put(CONNECTED_SENSORS.LEFT_INDICATOR, new Sensor(0, MAX_FADE_CURRENT));
 		sensors.put(CONNECTED_SENSORS.ODOMETER, new Sensor(0, 1));
-		sensors.put(CONNECTED_SENSORS.RIGHT_INDICATOR, new Sensor(0, 1));
+		sensors.put(CONNECTED_SENSORS.RIGHT_INDICATOR, new Sensor(0, MAX_FADE_CURRENT));
 		sensors.put(CONNECTED_SENSORS.TEMPERATURE, new Sensor(60, 135, 110));
 		sensors.put(CONNECTED_SENSORS.TRIP, new Sensor(0, 1));
 	}

--- a/src/BikeSack/BikeSack.java
+++ b/src/BikeSack/BikeSack.java
@@ -7,7 +7,7 @@ import java.util.Scanner;
 public class BikeSack {
 
 	
-	public static final int MAX_FADE_CURRENT = 10;
+	public static final int MAX_FADE_CURRENT = 15;
 
 	// Set up constants for the keyboard inputs
 	public static final String LEFT_INDICATOR_KEY = "L";

--- a/src/BikeSack/ConsoleDisplay.java
+++ b/src/BikeSack/ConsoleDisplay.java
@@ -36,6 +36,10 @@ public class ConsoleDisplay extends Display {
 		System.out.println("Fuel=" + fuelLevel.getPercentage() + "% " + String.format("%12s", "") + "Engine Temp= "+ temperature.getCurrent() + temperature.getUnitSymbol());
 		System.out.println("0[" + fuelLevel + "]100" + String.format("%4s", "") + "min["+temperature+"]max");
 		System.out.println();
+		System.out.println("Left Indicator" + String.format("%7s", "") + "Right Indicator");
+		System.out.println(" [" + buildIndicator(instruments.get(INSTRUMENTS.LEFT_INDICATOR)) + "]   " +
+		        String.format("%4s", "") + "   [" + buildIndicator(instruments.get(INSTRUMENTS.RIGHT_INDICATOR)) + "]   ");
+		System.out.println();
 		System.out.println("Odometer=0000000" + String.format("%4s", "") + "Trip Meter=0");
 		System.out.println();
 		System.out.println("Fuel Usage= 0.0Km/100L");
@@ -43,4 +47,31 @@ public class ConsoleDisplay extends Display {
 		System.out.println("Please enter a selection:");
 
 	}
+	
+	public String buildIndicator(Instrument indicator) {
+        String indicatorString;
+        int indicatorLen = 10;
+        char onChar = '#';
+        
+        if(indicator.getCurrent() == 0) {
+            indicatorString = "          ";
+            return indicatorString;
+        }
+        else {
+            // Get the fade level from the current
+            int fadeLevel = indicator.getCurrent();
+            StringBuilder indicatorBuilder = new StringBuilder();
+            for(int i = 0; i < indicatorLen; ++i )
+            {
+                if(i < fadeLevel) {
+                    indicatorBuilder.append(onChar);
+                }
+                else {
+                    indicatorBuilder.append(' ');
+                }
+            }
+            indicator.setCurrent(++fadeLevel);    
+            return indicatorBuilder.toString();
+        }
+    }
 }

--- a/src/BikeSack/ConsoleDisplay.java
+++ b/src/BikeSack/ConsoleDisplay.java
@@ -6,10 +6,12 @@ import BikeSack.BikeSack.INSTRUMENTS;
 
 public class ConsoleDisplay extends Display {
     
-    // 
-    private final static int NUM_INDICATOR_LOOPS = 29;
+    private final static int NUM_INDICATOR_LOOPS = 42;
     private final static int INDICATOR_LOOP_DELAY = 90;
     private int indicatorLoopCounter = 0;
+    
+    // Fade direction in/out
+    private boolean indicatorFadeIn = true;
 
 	// Print the console GUI
 	public void show(Map<INSTRUMENTS, Instrument> instruments) {
@@ -77,18 +79,11 @@ public class ConsoleDisplay extends Display {
 
 	
 	private String buildIndicator(Instrument indicator) {
-        
-        //int indicatorLen = 15;
         char onChar = '*';
         
         // Check if indicator is off
         if(indicator.getCurrent() == 0) {
             return "               ";
-        }
-        
-        // Reset if at the max fade length
-        if(indicator.getCurrent() >= BikeSack.MAX_FADE_CURRENT) {
-            indicator.setCurrent(0);
         }
         
         // Get the fade level from the current
@@ -98,14 +93,28 @@ public class ConsoleDisplay extends Display {
         StringBuilder indicatorBuilder = new StringBuilder();
         for(int i = 0; i < BikeSack.MAX_FADE_CURRENT; ++i )
         {
-            if(i < fadeLevel + 1) {
+            if(i < fadeLevel) {
                 indicatorBuilder.append(onChar);
             }
             else {
                 indicatorBuilder.append(' ');
             }
         }
-        indicator.setCurrent(++fadeLevel);    
+        
+        // Toggle fade direction when it reaches the end of the indicator
+        if(fadeLevel == BikeSack.MAX_FADE_CURRENT) {
+            indicatorFadeIn = false; 
+        } else if (fadeLevel == 1) {
+            indicatorFadeIn = true;
+        }
+            
+        // Increment/decrement depending on fade direction
+        if(indicatorFadeIn) {
+            indicator.setCurrent(++fadeLevel);
+        } else {
+            indicator.setCurrent(--fadeLevel);
+        }
+        
         return indicatorBuilder.toString();
     }
 	

--- a/src/BikeSack/Instrument.java
+++ b/src/BikeSack/Instrument.java
@@ -17,4 +17,11 @@ public abstract class Instrument {
 	}
 
 	public abstract String toString();
+
+    public boolean isOn() {
+        if(current > 0) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/BikeSack/RangeInstrument.java
+++ b/src/BikeSack/RangeInstrument.java
@@ -38,12 +38,6 @@ public class RangeInstrument extends Instrument {
    private boolean maxWarning, warningActive;
    private String unit, unitSymbol;
 
-   public RangeInstrument() {
-      // Default amounts
-      min = 0;
-      max = 50;
-   }
-
    public RangeInstrument(int max) {
       min = 0;
       this.max = max;
@@ -155,7 +149,6 @@ public class RangeInstrument extends Instrument {
       int totalLevelChars = 10;
 
       // Calculate percentage
-      // double gaugeLevel = ( (double)super.getCurrent() / (double)max ) * 100.0;
       int gaugeLevel = this.getPercentage();
 
       int numFullChars = gaugeLevel / totalLevelChars;

--- a/src/BikeSack/Sensor.java
+++ b/src/BikeSack/Sensor.java
@@ -80,6 +80,15 @@ public class Sensor {
 		}
 	}
 
+	// Toggle with a custom on value
+	public void toggle(int onValue) throws SensorException {
+        if (getCurrent() > min) {
+            setCurrent(min);
+        } else {
+            setCurrent(onValue);
+        }
+    }
+	
 	public void increase() throws SensorException {
 		setCurrent(getCurrent() + INCREMENT);
 	}


### PR DESCRIPTION
Indicators now fade in the updated console display. When the indicator is turned on the console GUI loops through a number of times to show the fading effect finally coming to a stop when the on indicator is full.